### PR TITLE
Add macosx_version_min option to linker

### DIFF
--- a/obfuscated/v-white/coding_challenge.py
+++ b/obfuscated/v-white/coding_challenge.py
@@ -9,7 +9,7 @@ import subprocess
 
 def oh_na_na_whats_my_name():
 	subprocess.call(['nasm', '-f', 'macho', 'my_name.asm']) #assemble
-	subprocess.call(['ld', '-o', 'my_name', 'my_name.o']) # link
+	subprocess.call(['ld', '-macosx_version_min', '10.7.0', '-o', 'my_name', 'my_name.o']) # link
 	my_name_exec = subprocess.Popen('./my_name', shell=True, stdout=subprocess.PIPE) # run and pipe to stdout
 	my_name_output = str(my_name_exec.stdout.read())
 	print my_name_output.strip().decode('hex')


### PR DESCRIPTION
The linker needed another option (`-macosx_version_min 10.7.0`) to work on my Macbook Air.

```
% sysctl -n machdep.cpu.brand_string
Intel(R) Core(TM) i7-5650U CPU @ 2.20GHz
```

```
uname -a
Darwin C02T37W6HF1R 17.7.0 Darwin Kernel Version 17.7.0: Thu Jun 21 22:53:14 PDT 2018; root:xnu-4570.71.2~1/RELEASE_X86_64 x86_64 i386 MacBookAir7,2 Darwin
```

Also needed to run `brew install nasm` as the one pre-installed would fail with

```
nasm: error: unable to find utility "nasm", not a developer tool or in PATH
```